### PR TITLE
Make compatible with Python versions earlier than 3.5

### DIFF
--- a/hypergan/multi_component.py
+++ b/hypergan/multi_component.py
@@ -37,7 +37,7 @@ class MultiComponent():
         if isinstance(data[0], type({})):
             full_dict = {}
             for d in data:
-                full_dict = {**full_dict, **d}
+                full_dict.update(d)
             return full_dict
         # loss functions return [d_loss, g_loss].  We combine columnwise.
         if isinstance(data, list) and isinstance(data[0], list) and isinstance(data[0][0], tf.Tensor):


### PR DESCRIPTION
This PR changes the code that updates `full_dict` so that it doesn't use the new unpacking operator introduced in Python 3.5 [[PEP 448](https://www.python.org/dev/peps/pep-0448/)]. With this change, HyperGAN should now work with Python versions earlier than 3.5.