### PR TITLE
Stopping pygame from crashing by adding a line to capture pygame events

### DIFF
--- a/hypergan/pygame_viewer.py
+++ b/hypergan/pygame_viewer.py
@@ -25,6 +25,7 @@ class PygameViewer:
             self.pg = pygame
             self.screen = self.pg.display.set_mode(size)
             self.pg.display.set_caption(self.title)
+        self.pg.event.get()
         surface = self.pg.Surface(size)
         self.pg.surfarray.blit_array(surface, image)
         self.screen.blit(surface, (0,0))


### PR DESCRIPTION
On both Mac and Windows, the pygame window that appears will crash whenever it is clicked on, or in a few seconds if the window is left alone. This edit seems to be the simple fix for the issue, so I hope that it (or some other change with the same effect) can be added to make HyperGAN more accessible to Mac and Windows users. 