### PR TITLE
Skip connections

### DIFF
--- a/hypergan/discriminators/base_discriminator.py
+++ b/hypergan/discriminators/base_discriminator.py
@@ -81,6 +81,10 @@ class BaseDiscriminator(GANComponent):
         return net
 
     def progressive_enhancement(self, config, net, xg):
-        if 'progressive_enhancement' in config and config.progressive_enhancement and xg is not None:
-            net = tf.concat(axis=3, values=[net, xg])
+        if config.skip_connection:
+            s = self.ops.shape(net)
+            extra = gan.skip_connections.get(config.skip_connection, [s[0], s[1], s[2], self.gan.channels()])
+            #TODO APpend X
+            tf.concat([extra, net], axis=1)
+
         return net

--- a/hypergan/gans/standard_gan.py
+++ b/hypergan/gans/standard_gan.py
@@ -19,6 +19,7 @@ from hyperchamber import Config
 from hypergan.ops import TensorflowOps
 import tensorflow as tf
 import hypergan as hg
+from hypergan.skip_connections import SkipConnections
 
 from hypergan.gan_component import ValidationException, GANComponent
 from .base_gan import BaseGAN
@@ -47,6 +48,7 @@ class StandardGAN(BaseGAN):
         self.loss = None
         self.trainer = None
         self.session = None
+        self.skip_connections = SkipConnections()
 
     def required(self):
         return "generator".split()

--- a/hypergan/generators/resize_conv_generator.py
+++ b/hypergan/generators/resize_conv_generator.py
@@ -100,7 +100,14 @@ class ResizeConvGenerator(BaseGenerator):
             s = ops.shape(net)
             resize = [min(s[1]*2, gan.height()), min(s[2]*2, gan.width())]
             net = self.layer_regularizer(net)
+
+            if config.skip_connection:
+                sliced = tf.slice(net, [0,0,0,0], [-1, -1, -1, gan.channels()]
+                sliced = final_activation(sliced)
+                gan.skip_connections.set(config.skip_connection, sliced, shape=ops.shape(sliced))
+
             net = activation(net)
+
             if block != 'deconv':
                 net = ops.resize_images(net, resize, config.resize_image_type or 1)
                 net = self.layer_filter(net)

--- a/hypergan/samplers/debug_sampler.py
+++ b/hypergan/samplers/debug_sampler.py
@@ -1,24 +1,30 @@
 from hypergan.samplers.base_sampler import BaseSampler
+from hypergan.samplers.began_sampler import BeganSampler
 from hypergan.samplers.batch_sampler import BatchSampler
 from hypergan.samplers.static_batch_sampler import StaticBatchSampler
 from hypergan.samplers.random_walk_sampler import RandomWalkSampler
 import tensorflow as tf
 import numpy as np
+import hypergan as hg
+from hypergan.losses.boundary_equilibrium_loss import BoundaryEquilibriumLoss
 
 class DebugSampler(BaseSampler):
     def __init__(self, gan, samples_per_row=8):
         BaseSampler.__init__(self, gan, samples_per_row)
         self.samplers = [
-            StaticBatchSampler(gan, samples_per_row),
-            BatchSampler(gan, samples_per_row),
-            RandomWalkSampler(gan, samples_per_row)
+          StaticBatchSampler(gan, samples_per_row),
+          BatchSampler(gan, samples_per_row),
+          RandomWalkSampler(gan, samples_per_row)
         ]
+        if gan.config.loss['class'] == BoundaryEquilibriumLoss:
+          self.samplers += [BeganSampler(gan, samples_per_row)]
+
+        print("GANLOSS", gan.loss.__class__.__name__)
 
 
     def _sample(self):
         samples = [sampler._sample()['generator'] for sampler in self.samplers]
         all_samples = np.vstack(samples)
-        print("ALL_SAMPLES:", np.shape(all_samples))
 
         return {
             'generator':all_samples

--- a/hypergan/skip_connections.py
+++ b/hypergan/skip_connections.py
@@ -1,0 +1,18 @@
+import hyperchamber as hc
+
+class SkipConnections:
+    def __init__(self):
+        self.connections = {}
+
+    def get(self, name, shape=None):
+        conns = hc.Config(self.connections)
+        conns = conns.name or []
+        for con in conns:
+            if con[0] == shape:
+                return con[1]
+        return None
+
+    def set(self, name, value, shape = None):
+        if not hasattr(self.connections, name):
+            self.connections[name] = []
+        self.connections[name].append([shape, value])

--- a/tests/skip_connections_test.py
+++ b/tests/skip_connections_test.py
@@ -1,0 +1,12 @@
+import hypergan as hg
+import tensorflow as tf
+from hypergan.skip_connections import SkipConnections
+
+
+sc = SkipConnections()
+class SkipConnectionsTest(tf.test.TestCase):
+    def test_get_none(self):
+        self.assertIsNone(sc.get('none'))
+
+if __name__ == "__main__":
+    tf.test.main()


### PR DESCRIPTION
A general way to do skip connections between different network configurations.

##### Getting generator skip connections

```python
connections = gan.skip_connections.get('generator', shape=current_layer.shape())
if connections is not None:
  current_layer = tf.concat([current_layer, connections], axis=3)
```

##### Setting generator skip connections
 
```python
gan.skip_connections.set('generator', current_layer, shape=current_layer.shape())

```

This replaces progressive enhancement(or is used by it).