### PR TITLE
'debug' sampler stacks multiple samplers

### DIFF
--- a/hypergan/cli.py
+++ b/hypergan/cli.py
@@ -22,6 +22,7 @@ from hypergan.samplers.aligned_sampler import AlignedSampler
 from hypergan.samplers.autoencode_sampler import AutoencodeSampler
 from hypergan.samplers.random_walk_sampler import RandomWalkSampler
 from hypergan.samplers.alphagan_random_walk_sampler import AlphaganRandomWalkSampler
+from hypergan.samplers.debug_sampler import DebugSampler
 
 from hypergan.losses.supervised_loss import SupervisedLoss
 from hypergan.multi_component import MultiComponent
@@ -66,6 +67,7 @@ class CLI:
                 'grid': GridSampler,
                 'began': BeganSampler,
                 'autoencode': AutoencodeSampler,
+                'debug': DebugSampler,
                 'aligned': AlignedSampler
         }
         if name in samplers:

--- a/hypergan/samplers/base_sampler.py
+++ b/hypergan/samplers/base_sampler.py
@@ -20,7 +20,7 @@ class BaseSampler:
             data = sample['generator']
 
             width = min(gan.batch_size(), self.samples_per_row)
-            stacks = [np.hstack(data[i*width:i*width+width]) for i in range(gan.batch_size()//width)]
+            stacks = [np.hstack(data[i*width:i*width+width]) for i in range(np.shape(data)[0]//width)]
             sample_data = np.vstack(stacks)
             self.plot(sample_data, path, save_samples)
             sample_name = 'generator'

--- a/hypergan/samplers/debug_sampler.py
+++ b/hypergan/samplers/debug_sampler.py
@@ -1,0 +1,26 @@
+from hypergan.samplers.base_sampler import BaseSampler
+from hypergan.samplers.batch_sampler import BatchSampler
+from hypergan.samplers.static_batch_sampler import StaticBatchSampler
+from hypergan.samplers.random_walk_sampler import RandomWalkSampler
+import tensorflow as tf
+import numpy as np
+
+class DebugSampler(BaseSampler):
+    def __init__(self, gan, samples_per_row=8):
+        BaseSampler.__init__(self, gan, samples_per_row)
+        self.samplers = [
+            StaticBatchSampler(gan, samples_per_row),
+            BatchSampler(gan, samples_per_row),
+            RandomWalkSampler(gan, samples_per_row)
+        ]
+
+
+    def _sample(self):
+        samples = [sampler._sample()['generator'] for sampler in self.samplers]
+        all_samples = np.vstack(samples)
+        print("ALL_SAMPLES:", np.shape(all_samples))
+
+        return {
+            'generator':all_samples
+        }
+

--- a/hypergan/trainers/multi_step_trainer.py
+++ b/hypergan/trainers/multi_step_trainer.py
@@ -60,6 +60,6 @@ class MultiStepTrainer(BaseTrainer):
                 metric_values = sess.run([optimizer] + self.output_variables(metric), feed_dict)[1:]
 
                 if self.current_step % 100 == 0:
-                    print("loss " + str(i) + "  "+ self.output_string(metric) % tuple([self.current_step] + metric_values))
+                    print("loss " + str(i) + "  "+ loss[0] + " " + self.output_string(metric) % tuple([self.current_step] + metric_values))
             else:
                 _ = sess.run(optimizer, feed_dict)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
   name = 'hypergan',
   packages = ['hypergan']+subpackages,
   include_package_data=True,
-  version = '0.9.4',
+  version = '0.9.5',
   description = 'A customizable generative adversarial network with reproducible configurations.  Build your own content generator.',
   author = 'Martyn Garcia, Mikkel Garcia',
   author_email = 'mikkel@255bits.com',


### PR DESCRIPTION
This sampler is useful for determining if there are parts of the network that are broken.  It stacks many different samplers on top of each other.

Specify it by using `-c debug` on the command line.