### PR TITLE
Code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,12 @@ HyperGAN is currently in open beta.
 
 # Documentation
 
-[API Documentation](https://s3.amazonaws.com/hypergan-apidocs/0.9.0/index.html)
+
+## API Documentation
+
+ * [0.10.0](https://s3.amazonaws.com/hypergan-apidocs/0.10.0/index.html)
+ * [0.9.x](https://s3.amazonaws.com/hypergan-apidocs/0.9.0/index.html)
+ * [Test coverage](https://s3.amazonaws.com/hypergan-apidocs/0.10.0/tests/coverage/index.html)
 
 # Changelog
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ HyperGAN is currently in open beta.
 
  * [0.10.0](https://s3.amazonaws.com/hypergan-apidocs/0.10.0/index.html)
  * [0.9.x](https://s3.amazonaws.com/hypergan-apidocs/0.9.0/index.html)
- * [Test coverage](https://s3.amazonaws.com/hypergan-apidocs/0.10.0/tests/coverage/index.html)
+ * [Test coverage](https://s3.amazonaws.com/hypergan-apidocs/0.10.0/coverage/index.html)
 
 # Changelog
 

--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,7 @@ deployment:
     - pdoc --html --overwrite hypergan
     - mkdir -p $CIRCLE_ARTIFACTS/apidocs
     - cp -R hypergan/* $CIRCLE_ARTIFACTS/apidocs
+    - cp -R test/coverage $CIRCLE_ARTIFACTS/coverage
     - aws s3 sync hypergan s3://hypergan-apidocs/0.10.0/ --delete --acl "public-read"
     - aws s3 sync tests/coverage s3://hypergan-codecoverage/0.10.0/ --delete --acl "public-read"
 

--- a/circle.yml
+++ b/circle.yml
@@ -9,11 +9,12 @@ test:
     - sh tests/run.sh
 deployment:
   docs:
-    branch: master
+    branch: [master, code-coverage]
     commands:
     - pdoc --html --overwrite hypergan
     - mkdir -p $CIRCLE_ARTIFACTS/apidocs
     - cp -R hypergan/* $CIRCLE_ARTIFACTS/apidocs
-    - aws s3 sync hypergan s3://hypergan-apidocs/0.9.0/ --delete --acl "public-read"
+    - aws s3 sync hypergan s3://hypergan-apidocs/0.10.0/ --delete --acl "public-read"
+    - aws s3 sync tests/coverage s3://hypergan-codecoverage/0.10.0/ --delete --acl "public-read"
 
     

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ test:
     - sh tests/run.sh
 deployment:
   docs:
-    branch: [master, code-coverage]
+    branch: [master, 0.10]
     commands:
     - pdoc --html --overwrite hypergan
     - mkdir -p $CIRCLE_ARTIFACTS/apidocs

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ deployment:
     - pdoc --html --overwrite hypergan
     - mkdir -p $CIRCLE_ARTIFACTS/apidocs
     - cp -R hypergan/* $CIRCLE_ARTIFACTS/apidocs
-    - cp -R test/coverage $CIRCLE_ARTIFACTS/coverage
+    - cp -R tests/coverage $CIRCLE_ARTIFACTS/coverage
     - aws s3 sync hypergan s3://hypergan-apidocs/0.10.0/ --delete --acl "public-read"
     - aws s3 sync tests/coverage s3://hypergan-codecoverage/0.10.0/ --delete --acl "public-read"
 

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ dependencies:
   pre:
     - pyenv global 3.5.3
   override:
-    - pip3 install tensorflow hyperchamber Pillow pdoc
+    - pip3 install tensorflow hyperchamber Pillow pdoc coverage
     - python3 setup.py develop
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -16,6 +16,6 @@ deployment:
     - cp -R hypergan/* $CIRCLE_ARTIFACTS/apidocs
     - cp -R tests/coverage $CIRCLE_ARTIFACTS/coverage
     - aws s3 sync hypergan s3://hypergan-apidocs/0.10.0/ --delete --acl "public-read"
-    - aws s3 sync tests/coverage s3://hypergan-codecoverage/0.10.0/ --delete --acl "public-read"
+    - aws s3 sync tests/coverage s3://hypergan-apidocs/0.10.0/coverage --delete --acl "public-read"
 
     

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,1 +1,1 @@
-CUDA_VISIBLE_DEVICES="" python3 -m nose tests --all-modules --nologcapture
+CUDA_VISIBLE_DEVICES="" python3 -m nose tests --all-modules --nologcapture --with-coverage --cover-html --cover-html-dir=tests/coverage --cover-package=hypergan


### PR DESCRIPTION
Runs the `nose` `coverage` plugin and uploads the results to a public s3 bucket.